### PR TITLE
Dev - split CXR DICOM dataset in three subsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 /data
+
+.DS_Store
+.vscode/

--- a/deepneumo/.gitignore
+++ b/deepneumo/.gitignore
@@ -1,0 +1,3 @@
+
+# Ignore dynaconf secret files
+.secrets.*

--- a/deepneumo/cli.py
+++ b/deepneumo/cli.py
@@ -1,0 +1,29 @@
+import click
+from config import settings
+
+from src.run import split_in_three
+
+@click.group()
+def cli():
+    pass
+
+@click.command()
+def do_split_in_three():
+    split_in_three(settings)
+
+@click.command()
+#@click.option('--which', default="internal")
+def do_training():
+    raise NotImplementedError()
+
+@click.command()
+#@click.option('--which', default="internal")
+def do_evaluation():
+    raise NotImplementedError()
+
+cli.add_command(do_preprocessing)
+cli.add_command(do_training)
+cli.add_command(do_evaluation)
+
+if __name__ == '__main__':
+    cli()

--- a/deepneumo/cli.py
+++ b/deepneumo/cli.py
@@ -21,7 +21,7 @@ def do_training():
 def do_evaluation():
     raise NotImplementedError()
 
-cli.add_command(do_preprocessing)
+cli.add_command(do_split_in_three)
 cli.add_command(do_training)
 cli.add_command(do_evaluation)
 

--- a/deepneumo/config.py
+++ b/deepneumo/config.py
@@ -1,0 +1,9 @@
+from dynaconf import Dynaconf
+
+settings = Dynaconf(
+    envvar_prefix="DYNACONF",
+    settings_files=['settings.py', '.secrets.toml'],
+)
+
+# `envvar_prefix` = export envvars with `export DYNACONF_FOO=bar`.
+# `settings_files` = Load these files in the order.

--- a/deepneumo/settings.py
+++ b/deepneumo/settings.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+DATA_DIR = Path.cwd().parents[0] / "data"
+DICOMS_DIR = DATA_DIR / "dicoms"
+LABELS_PATH = DATA_DIR / "ground_truths.csv"
+PREPROC_DIR = DATA_DIR / "preproc"
+
+ID_COLUMN = "patientId"
+TARGET_COLUMN = "Target"
+
+IMG_SIZE = (224, 224)
+
+SPLIT_SIZE = (.8, .1, .1)
+SUBSET_NAMES = ("train", "dev", "test")
+
+SEED = 1234

--- a/deepneumo/settings.py
+++ b/deepneumo/settings.py
@@ -10,7 +10,6 @@ TARGET_COLUMN = "Target"
 
 IMG_SIZE = (224, 224)
 
-SPLIT_SIZE = (.8, .1, .1)
-SUBSET_NAMES = ("train", "dev", "test")
+SPLIT_SIZE = {"train": .8, "dev": .1, "test": .1}
 
 SEED = 1234

--- a/deepneumo/settings.py
+++ b/deepneumo/settings.py
@@ -1,15 +1,21 @@
 from pathlib import Path
 
-DATA_DIR = Path.cwd().parents[0] / "data"
+#DATA_DIR = Path.cwd().parents[0] / "data"
+DATA_DIR = Path.cwd() / "data"
 DICOMS_DIR = DATA_DIR / "dicoms"
 LABELS_PATH = DATA_DIR / "ground_truths.csv"
-PREPROC_DIR = DATA_DIR / "preproc"
+TRAIN_DIR = DATA_DIR / "train"
+VAL_DIR = DATA_DIR / "val"
+TEST_DIR = DATA_DIR / "test"
+
 
 ID_COLUMN = "patientId"
 TARGET_COLUMN = "Target"
+CONTROL_CLASS = "control"
+CONDITION_CLASS = "pneumonia"
 
 IMG_SIZE = (224, 224)
 
-SPLIT_SIZE = {"train": .8, "dev": .1, "test": .1}
+SPLIT_SIZE = {"train": .8, "val": .1, "test": .1}
 
 SEED = 1234

--- a/deepneumo/src/_typings.py
+++ b/deepneumo/src/_typings.py
@@ -1,0 +1,16 @@
+import numpy
+import random
+import sys
+from typing import Union
+
+try:
+    from numpy.typing import ArrayLike
+except ImportError:
+    ArrayLike = Union[numpy.ndarray, List[List[float]]]
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+Seed: TypeAlias = Union[int, random.seed, numpy.random.seed]

--- a/deepneumo/src/run.py
+++ b/deepneumo/src/run.py
@@ -1,0 +1,66 @@
+import cv2
+from tqdm import tqdm
+import pydicom
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from typing import Tuple
+import shutil
+
+from src.utils.data import three_way_split
+
+__all__ = ['split_in_three', 'train_epoch', 'eval_model']
+
+def split_in_three(conf):
+    """
+    Perform a stratified split of the X-ray images in three subsets.
+    After splitting patient IDs and ground-truths in three subsets,
+    corresponding dicoms are placed in the train, val or test folder
+    depending on the ground-truth value (normal or pneumonia subfolders).
+
+    Arguments
+    ---------
+    conf 
+        a DynaConf settings object
+    """
+    # read labels and drop duplicates based on patient ID
+    labels = pd.read_csv(conf.LABELS_PATH)
+    labels = labels.drop_duplicates(conf.ID_COLUMN)
+
+    # split in train, validation and test sets
+    train, val, test = three_way_split(labels, conf.SPLIT_SIZE, conf.TARGET_COLUMN, conf.SEED)
+
+    # dicoms = [x.name for x in Path(conf.DICOMS_DIR).iterdir() if x.is_file()]
+    for x in Path(conf.DICOMS_DIR).iterdir():
+        if x.is_file() and not x.suffix:
+            x.rename(x.with_suffix(".dcm"))
+
+    for subset_name, subset in zip(conf.SPLIT_SIZE.keys(), [train, val, test]):
+        # create folder for subset if not exists
+        subset_dir = conf[f"{subset_name.upper()}_DIR"]
+        Path(subset_dir).mkdir(parents=True, exist_ok=True)
+        Path(subset_dir / conf.CONTROL_CLASS).mkdir(parents=True, exist_ok=True)
+        Path(subset_dir / conf.CONDITION_CLASS).mkdir(parents=True, exist_ok=True)
+
+        # iterate over tuples of patient Id and ground-truth for current subset
+        for pid, gt in subset[[conf.ID_COLUMN, conf.TARGET_COLUMN]].itertuples(index=False):
+            curr_dcm = (conf.DICOMS_DIR / str(pid)).with_suffix(".dcm")
+            if gt:
+                shutil.copy(curr_dcm, (subset_dir / conf.CONTROL_CLASS / str(pid)).with_suffix(".dcm"))
+            else:
+                shutil.copy(curr_dcm, (subset_dir / conf.CONDITION_CLASS / str(pid)).with_suffix(".dcm"))
+
+def train_step():
+    raise NotImplementedError()
+
+
+def train_epoch():
+    raise NotImplementedError()
+
+
+def eval_step():
+    raise NotImplementedError()
+
+
+def eval_model():
+    raise NotImplementedError()

--- a/deepneumo/src/utils/data.py
+++ b/deepneumo/src/utils/data.py
@@ -1,0 +1,57 @@
+import numpy as np
+import pandas as pd
+from typing import Tuple
+from sklearn.model_selection import train_test_split
+
+from .._typings import ArrayLike, Seed
+
+def three_way_split(data, size, stratify = None, random_state=None):
+    """_summary_
+
+    Args:
+        data (_type_): _description_
+        size (_type_): _description_
+        stratify (_type_, optional): _description_. Defaults to None.
+        random_state (_type_, optional): _description_. Defaults to None.
+
+    Raises:
+        ValueError: _description_
+        ValueError: _description_
+
+    Returns:
+        _type_: _description_
+    """
+    sizes = size.values()
+    if not sum(sizes) == 1.0:
+        raise ValueError('fractions {0}, {1}, {2} do not add up to 1.0'.format(*sizes))
+    
+    if isinstance(data, np.ndarray):
+        # in this case, columns are range from 0 to N-1 (N is no. of columns)
+        data = pd.DataFrame(data)
+
+    if not stratify:
+        stratify = data.columns[-1]
+    else:
+        if not stratify in data.columns:
+            raise ValueError(f'{stratify} is not a column in the dataframe')
+
+    # X = df_input # Contains all columns.
+    # y = df_input[[stratify_colname]] # Dataframe of just the column on which to stratify.
+
+    train_frac, val_frac, test_frac = sizes
+
+    # Split original dataframe into train and temp dataframes.
+    df_train, df_temp = train_test_split(data, stratify=data[stratify],
+                                        test_size=(1.0 - train_frac),
+                                        random_state=random_state)
+
+    # Split the temp dataframe into val and test dataframes.
+    relative_test_frac = test_frac / (val_frac + test_frac)
+    df_val, df_test = train_test_split(df_temp, 
+                                        stratify=df_temp[stratify],
+                                        test_size=relative_test_frac,
+                                        random_state=random_state)
+
+    # assert len(data) == len(df_train) + len(df_val) + len(df_test)
+
+    return df_train, df_val, df_test

--- a/deepneumo/src/utils/data.py
+++ b/deepneumo/src/utils/data.py
@@ -1,18 +1,31 @@
 import numpy as np
 import pandas as pd
-from typing import Tuple
+import pydicom
+from typing import Tuple, Dict, Optional
 from sklearn.model_selection import train_test_split
+from tqdm import tqdm
 
 from .._typings import ArrayLike, Seed
 
-def three_way_split(data, size, stratify = None, random_state=None):
-    """_summary_
+__all__ = ["three_way_split"]
 
-    Args:
-        data (_type_): _description_
-        size (_type_): _description_
-        stratify (_type_, optional): _description_. Defaults to None.
-        random_state (_type_, optional): _description_. Defaults to None.
+def three_way_split(data: ArrayLike, size: Dict[str, float], 
+                    stratify: Optional[str] = None, 
+                    random_state: Seed = 0):
+    """
+    Executes a stratified split of a data array in three different subsets 
+    - train, val and test - according to `size`.
+
+    Attributes
+    ----------
+    data: ArrayLike
+        The data array to be split in three.
+    size: Dict[str, float] 
+        Fraction of data array for each of three subsets. Must sum to 1.0.
+    stratify: Optional[str] 
+        The column to stratify the split on. Defaults to None.
+    random_state: Seed: 
+        The seed that controls the shuffling before the split. Defaults to 0.
 
     Raises:
         ValueError: _description_

--- a/deepneumo/src/utils/misc.py
+++ b/deepneumo/src/utils/misc.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+def count_files_in_dir(path: Path) -> int:
+    """Count files recursively in a directory.
+
+    Parameters
+    ----------
+    path : Path
+        The directory to count files of.
+
+    Returns
+    -------
+    int
+        Number of files in the directory
+    """
+    if not isinstance(path, Path):
+        if isinstance(path, str):
+            path = Path(path)
+        else:
+            raise ValueError("Path to ground-truth file isn't either string or PosixPath")    
+    
+    n_files = len([f for f in path.glob("**/*") if f.is_file()])
+
+    return n_files

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,9 +11,11 @@ dependencies:
   - mlflow
   - albumentations
   - pip
+  - pydicom
   - pip:
     - click
     - pytest
     - pytest-cov
     - dynaconf
+    - typing-extensions
 prefix: ./venv

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,19 @@
+name: venv
+channels:
+  - pytorch-nightly
+  - conda-forge
+dependencies:
+  - python=3.9.0
+  - pytorch-nightly::pytorch
+  - numpy
+  - tqdm
+  - pydantic
+  - mlflow
+  - albumentations
+  - pip
+  - pip:
+    - click
+    - pytest
+    - pytest-cov
+    - dynaconf
+prefix: ./venv

--- a/scripts/split-dataset.sh
+++ b/scripts/split-dataset.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v python &> /dev/null; then
+  echo "error: python not found"
+  exit 127
+fi
+
+SRC_DIR=deepneumo
+PYPATH="${PWD}"/venv/bin
+
+"${PYPATH}"/python "${SRC_DIR}"/cli.py do-split-in-three

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+import numpy as np
+
+from deepneumo import settings
+from deepneumo.src._typings import Seed
+
+### Define fixtures
+@pytest.fixture
+def rng() -> np.random.Generator:
+    """Construct a new Random Generator using the seed specified in settings.
+
+    Returns:
+        numpy.random.Generator: a Random Generator based on BitGenerator(PCG64)
+    """
+    return np.random.default_rng(settings.SEED)
+
+@pytest.fixture
+def random_state() -> Seed:
+    """Construct a new Random Generator using the seed specified in settings.
+
+    Returns:
+        numpy.random.Generator: a Random Generator based on BitGenerator(PCG64)
+    """
+    return np.random.RandomState(seed=settings.SEED)
+
+@pytest.fixture
+def data_array(dim, rng):
+    """Generates a data array of this size
+
+    Args:
+        dim (Tuple[int]): Dimension of the data array. It is passed by the test function
+    """
+    features = np.ones(dim)
+    target = rng.integers(low=0, high=2, size=(dim[0],))
+    return np.column_stack((features, target))
+
+@pytest.fixture
+def target():
+    return settings.TARGET_COLUMN

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,19 @@
 import pytest
 import numpy as np
+import random
+import string
 
 from deepneumo import settings
 from deepneumo.src._typings import Seed
 
 ### Define fixtures
+
+class Cases:
+    SPLIT_SIZES = [
+        ({'train': 0.8, 'val': 0.1, 'test': 0.1}),
+        ({'train': 0.6, 'val': 0.2, 'test': 0.2})
+    ]
+
 @pytest.fixture
 def rng() -> np.random.Generator:
     """Construct a new Random Generator using the seed specified in settings.
@@ -24,13 +33,23 @@ def random_state() -> Seed:
     return np.random.RandomState(seed=settings.SEED)
 
 @pytest.fixture
-def data_array(dim, rng):
+def alphanumeric_strings(dim, rng):
+    keys = rng.choice(list(string.ascii_letters) + list(string.digits), size=(dim[0], 10))
+    keys = np.apply_along_axis(
+        lambda v: ''.join(v), 
+        axis = 1, arr=keys)
+    return keys
+
+@pytest.fixture
+def data_array(dim, rng, alphanumeric_strings):
     """Generates a data array of this size
 
     Args:
         dim (Tuple[int]): Dimension of the data array. It is passed by the test function
     """
-    features = np.ones(dim)
+    # no need to call a fixture. Just specify it as an argument
+    # and it will return whatever it should return
+    features = alphanumeric_strings
     target = rng.integers(low=0, high=2, size=(dim[0],))
     return np.column_stack((features, target))
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pathlib import Path
+import logging
+import math
+
+from deepneumo.src.run import split_in_three
+from deepneumo.src.utils import misc
+from conftest import Cases
+
+
+@pytest.fixture
+def conf(tmp_path):
+    c = {
+        "LABELS_PATH": tmp_path / 'data' / 'ground_truths.csv',
+        "ID_COLUMN": None,
+        "TARGET_COLUMN": None,
+        "SEED": 1234,
+        "DICOMS_DIR": tmp_path / 'data' / 'dicoms',
+        "TRAIN_DIR": tmp_path / 'data' / 'dicoms' / 'train',
+        "VAL_DIR": tmp_path / 'data' / 'dicoms' / 'val',
+        "TEST_DIR": tmp_path / 'data' / 'dicoms' / 'test',
+        "CONTROL_CLASS": "normal",
+        "CONDITION_CLASS": "pneumonia"
+    }
+
+    return c
+
+
+@pytest.mark.parametrize('dim', [(100, 100), (1000, 100), (5000, 100)])
+@pytest.mark.parametrize('split_size', Cases.SPLIT_SIZES)
+def test_split_in_three(data_array, dim, split_size, tmp_path, conf):
+    # write data_array to conf["LABELS_PATH"]
+    (tmp_path / 'data').mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(data_array).to_csv(conf.get("LABELS_PATH"), index=False)
+
+    dicoms_dir = tmp_path / 'data' / 'dicoms'
+    dicoms_dir.mkdir(parents=True, exist_ok=True)
+
+    def touch_file(filepath):
+        filepath.with_suffix(".dcm").write_text("1")
+    
+    np.apply_along_axis(
+        lambda k: touch_file(dicoms_dir / k.item()),
+        axis=1, arr=data_array[:, [0]]
+    )
+
+    # n_files = len(list(Path(dicoms_dir).glob("*")))
+    n_dicoms = misc.count_files_in_dir(Path(dicoms_dir))
+    assert n_dicoms == data_array.shape[0]
+    
+
+    split_in_three(conf, split_size)
+
+    for subset_name in split_size.keys():
+        n_subset_dicoms = misc.count_files_in_dir(conf.get(f"{subset_name.upper()}_DIR"))
+        assert math.floor(dim[0] * split_size[subset_name]) == n_subset_dicoms
+    
+
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import pytest
+import logging
+
+from deepneumo.src.utils import data
+
+class Cases:
+    SPLIT_SIZES = [
+        ({'train': 0.8, 'val': 0.1, 'test': 0.1}),
+        ({'train': 0.6, 'val': 0.2, 'test': 0.2})
+    ]
+
+@pytest.mark.parametrize('dim', [(100, 100), (1000, 100), (5000, 100)])
+@pytest.mark.parametrize('split_size', Cases.SPLIT_SIZES)
+def test_three_way_split(data_array, dim, split_size, target, random_state):
+    df_train, df_val, df_test = data.three_way_split(data_array, split_size, None, random_state)
+    assert df_train.shape[0] == split_size["train"] * dim[0]
+    assert df_val.shape[0] == split_size["val"] * dim[0]
+    assert df_test.shape[0] == split_size["test"] * dim[0]
+    

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,12 +2,7 @@ import pytest
 import logging
 
 from deepneumo.src.utils import data
-
-class Cases:
-    SPLIT_SIZES = [
-        ({'train': 0.8, 'val': 0.1, 'test': 0.1}),
-        ({'train': 0.6, 'val': 0.2, 'test': 0.2})
-    ]
+from conftest import Cases
 
 @pytest.mark.parametrize('dim', [(100, 100), (1000, 100), (5000, 100)])
 @pytest.mark.parametrize('split_size', Cases.SPLIT_SIZES)


### PR DESCRIPTION
This pull request implements stratified three-way-splitting of the CXR DICOM dataset.
The whole dataset can be split according to `settings.SPLIT_SIZE` in three subsets, with stratification based on the target column (i.e., pneumonia or normal CXR).
The split procedure can either be accessed via the CLI or using a shell script which can be found on the scripts folder.